### PR TITLE
Implemented flags as better alternative to environment variables

### DIFF
--- a/lib/handle_flags.js
+++ b/lib/handle_flags.js
@@ -1,0 +1,26 @@
+const flags = require('flags');
+
+flags.defineBoolean('test')
+    .setDefault(false)
+    .setDescription('Use this flag to print information in the console.');
+
+flags.defineString('channel')
+    .setDefault('web_ids_requests')
+    .setDescription('Redis channel to listen to.' +
+                    ' Channel must be JSON formatted.');
+
+flags.defineBoolean('local')
+    .setDefault(false)
+    .setDescription('Used for local testing where redis is not available')
+    .setSecret(true);
+
+flags.usageInfo = 'Usage: web_ids [options]';
+
+flags.parse();
+
+module.exports = {
+  test: flags.get('test'),
+  local: flags.get('local'),
+  channel: flags.get('channel'),
+}
+;

--- a/lib/web_ids.js
+++ b/lib/web_ids.js
@@ -1,10 +1,8 @@
 // read environment variables from .env file
-require('dotenv').config();
-
 const redis = require('redis');
 const fs = require('fs');
 const path = require('path');
-
+const {test, local, channel} = require('./handle_flags');
 
 // global vars that store signatures
 let IP_SIGNATURES = [];
@@ -22,13 +20,17 @@ function init() {
   const messageCount = 0;
   loadSignatures(path.join(__dirname, '..', 'signatures'));
 
-  if (process.env.DEV_ENV && process.env.DEV_ENV !== 'development') {
+  if (!local) {
     const subscriber = redis.createClient();
 
     subscriber.on('message', (_channel, message) => {
       messageCount += 1;
 
       const formattedMessage = JSON.parse(message);
+
+      if (test) {
+        console.log(formattedMessage);
+      }
 
       performChecks(formattedMessage);
     });
@@ -77,7 +79,7 @@ function loadSignatures(dirname) {
     }
   });
 
-  if (process.env.DEV_ENV && process.env.DEV_ENV === 'development') {
+  if (local) {
     console.log('Loaded: ');
     console.log(`${IP_SIGNATURES.length} ip signatures,`);
     console.log(`${HEADER_SIGNATURES.length} header signatures,`);
@@ -144,12 +146,11 @@ function checkRequestStatus(requestStatus) {
  * @param {String} type of message ( e.g. Intrusion detected )
  * @param {String} message that will be written to the file
  * */
-function appendToLog(filePath, type, message){
+function appendToLog(filePath, type, message) {
+  const currDateTime = new Date().toUTCString();
 
-let currDateTime = new Date().toUTCString();
-  
-var logMessage = '[' + currDateTime + '] [' + type + ']' + ': '+ message;
-fs.appendFile(filepath, logMessage);  
+  const logMessage = '[' + currDateTime + '] [' + type + ']' + ': '+ message;
+  fs.appendFile(filepath, logMessage);
 }
 exports.startDetection = () => {
   init();

--- a/package-lock.json
+++ b/package-lock.json
@@ -473,6 +473,11 @@
         "flat-cache": "^3.0.4"
       }
     },
+    "flags": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/flags/-/flags-0.1.3.tgz",
+      "integrity": "sha1-lh0vyM3zZp1jBB4w5bJK2tNvV1g="
+    },
     "flat-cache": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "homepage": "https://github.com/mhatzl/web_ids#readme",
   "dependencies": {
     "dotenv": "^8.2.0",
+    "flags": "^0.1.3",
     "redis": "^3.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This fixes #5 . It seems cleaner and better to me. 
The package used works really nicely. [flags on npm](https://www.npmjs.com/package/flags)

Example how it looks like:

```
❯ web_ids --help
Usage: web_ids [options]

Options:
  --[no]test: Use this flag to print information in the console.
    (default: false)
  --channel: Redis channel to listen to. Channel must be JSON formatted.
    (default: "web_ids_requests")
```