### PR TITLE
fix-log-consistency

### DIFF
--- a/doc/FetchingLogs.md
+++ b/doc/FetchingLogs.md
@@ -8,8 +8,8 @@ The fixed JSON-format looks as follows:
 	"timestamp" : "<Monthname> <Day> <HH:MM:SS>",
 	"service" : "<nginx, apache, ...>",
 	"srcip" : "<source ip-address>",
-	"request_method" : "<request method>",
-	"request_uri" : "<requested uri>",
+	"method" : "<request method>",
+	"uri" : "<requested uri>",
 	"status" : "<request status>",
 	"body" : "<request body>"
 }
@@ -57,13 +57,13 @@ template(name="web_ids_json" type="list" ){
     regex.expression="[[:digit:].]+"
   )
   constant(value=",")
-  property(name="msg" outname="request_method" format="jsonf"
+  property(name="msg" outname="method" format="jsonf"
     regex.type="ERE"
     regex.expression=": \"([[:alpha:]]+)\" :"
     regex.submatch="1"
   )
   constant(value=",")
-  property(name="msg" outname="request_uri" format="jsonf"
+  property(name="msg" outname="uri" format="jsonf"
     regex.type="ERE"
     regex.expression="[[:alpha:]]+\" : \"(.*)\" :"
     regex.submatch="1"

--- a/lib/web_ids.js
+++ b/lib/web_ids.js
@@ -94,8 +94,8 @@ function performChecks(message) {
   if (!message) return;
 
   checkIp(message.srcip);
-  checkRequestBody(message.request_body);
-  checkRequestUri(message.request_uri);
+  checkRequestBody(message.body);
+  checkRequestUri(message.uri);
   checkRequestStatus(message.status);
 }
 

--- a/lib/web_ids.js
+++ b/lib/web_ids.js
@@ -116,16 +116,11 @@ function checkIp(srcIp) {
 }
 
 /**
- * Check if request body contains offending data
- * @param {Object} request JSON containing request data
- * Request can have following options: request_method, request_uri,
- * status and body
+ * Check if request contains offending data
+ * @param {Object} request JSON containing request data.
+ * A request can have the following options: method, uri, status and body
  * */
 function checkRequest(request) {
-  // TODO
-  // file with signatures should be read and request uri's stored
-  // match them here
-
   const method = request.method;
   const uri = request.uri;
   const status = request.status;


### PR DESCRIPTION
This fixes #8  by removing unnecessary request prefixes in log fields 