### PR TITLE
Fix doc for regex matches on retrieving log messages

### DIFF
--- a/doc/FetchingLogs.md
+++ b/doc/FetchingLogs.md
@@ -54,31 +54,31 @@ template(name="web_ids_json" type="list" ){
   constant(value=",")
   property(name="msg" outname="srcip" format="jsonf"
     regex.type="ERE"
-    regex.expression="([[:digit:].]+) : \"[[:alpha:]]+\" : \".*\" : [[:digit:]]+ : \".*\""
+    regex.expression="([[:graph:]]+) : \"[[:graph:]]+\" : \".*\" : [[:graph:]]+ : \".*\""
     regex.submatch="1"
   )
   constant(value=",")
   property(name="msg" outname="method" format="jsonf"
     regex.type="ERE"
-    regex.expression="[[:digit:].]+ : \"([[:alpha:]]+)\" : \".*\" : [[:digit:]]+ : \".*\""
+    regex.expression="[[:graph:]]+ : \"([[:graph:]]+)\" : \".*\" : [[:graph:]]+ : \".*\""
     regex.submatch="1"
   )
   constant(value=",")
   property(name="msg" outname="uri" format="jsonf"
     regex.type="ERE"
-    regex.expression="[[:digit:].]+ : \"[[:alpha:]]+\" : \"(.*)\" : [[:digit:]]+ : \".*\""
+    regex.expression="[[:graph:]]+ : \"[[:graph:]]+\" : \"(.*)\" : [[:graph:]]+ : \".*\""
     regex.submatch="1"
   )
   constant(value=",")
   property(name="msg" outname="status" format="jsonf"
     regex.type="ERE"
-    regex.expression="[[:digit:].]+ : \"[[:alpha:]]+\" : \".*\" : ([[:digit:]]+) : \".*\""
+    regex.expression="[[:graph:]]+ : \"[[:graph:]]+\" : \".*\" : ([[:graph:]]+) : \".*\""
     regex.submatch="1"
   )
   constant(value=",")
   property(name="msg" outname="body" format="jsonf"
     regex.type="ERE"
-    regex.expression="[[:digit:].]+ : \"[[:alpha:]]+\" : \".*\" : [[:digit:]]+ : \"(.*)\""
+    regex.expression="[[:graph:]]+ : \"[[:graph:]]+\" : \".*\" : [[:graph:]]+ : \"(.*)\""
     regex.submatch="1"
   )
   constant(value="}")

--- a/doc/FetchingLogs.md
+++ b/doc/FetchingLogs.md
@@ -54,30 +54,31 @@ template(name="web_ids_json" type="list" ){
   constant(value=",")
   property(name="msg" outname="srcip" format="jsonf"
     regex.type="ERE"
-    regex.expression="[[:digit:].]+"
+    regex.expression="([[:digit:].]+) : \"[[:alpha:]]+\" : \".*\" : [[:digit:]]+ : \".*\""
+    regex.submatch="1"
   )
   constant(value=",")
   property(name="msg" outname="method" format="jsonf"
     regex.type="ERE"
-    regex.expression=": \"([[:alpha:]]+)\" :"
+    regex.expression="[[:digit:].]+ : \"([[:alpha:]]+)\" : \".*\" : [[:digit:]]+ : \".*\""
     regex.submatch="1"
   )
   constant(value=",")
   property(name="msg" outname="uri" format="jsonf"
     regex.type="ERE"
-    regex.expression="[[:alpha:]]+\" : \"(.*)\" :"
+    regex.expression="[[:digit:].]+ : \"[[:alpha:]]+\" : \"(.*)\" : [[:digit:]]+ : \".*\""
     regex.submatch="1"
   )
   constant(value=",")
   property(name="msg" outname="status" format="jsonf"
     regex.type="ERE"
-    regex.expression="[[:alpha:]]+\" : \".*\" : ([[:digit:]]+)"
+    regex.expression="[[:digit:].]+ : \"[[:alpha:]]+\" : \".*\" : ([[:digit:]]+) : \".*\""
     regex.submatch="1"
   )
   constant(value=",")
   property(name="msg" outname="body" format="jsonf"
     regex.type="ERE"
-    regex.expression="[[:alpha:]]+\" : \".*\" : [[:digit:]]+ : \"(.*)\""
+    regex.expression="[[:digit:].]+ : \"[[:alpha:]]+\" : \".*\" : [[:digit:]]+ : \"(.*)\""
     regex.submatch="1"
   )
   constant(value="}")


### PR DESCRIPTION
Fixed regex matches so every field gets extracted of the full log message.
It is still very general, but thats fine, since we only want the fields to be identifiable.