### PR TITLE
Fix matching and typo in checkRequest

### DIFF
--- a/lib/web_ids.js
+++ b/lib/web_ids.js
@@ -129,14 +129,14 @@ function checkRequest(request) {
   let type = '';
 
   for (const signature of REQUEST_SIGNATURES) {
-    let hasMatch = false;
+    let hasMatch = true;
 
     if (signature.method) {
-      hasMatch = method.match(signature.method);
+      hasMatch = method.match(signature.method) && hasMatch;
     }
 
     if (signature.uri) {
-      hasMatch = uri.match(signature.ur) && hasMatch;
+      hasMatch = uri.match(signature.uri) && hasMatch;
     }
 
     if (signature.status) {


### PR DESCRIPTION
This fixes #15 
Now requestSignature matches with AND concatenation of all fields and the uri field is passed correctly