### PR TITLE
Matched signature now written as JSON on request match. + light message formatting

### DIFF
--- a/lib/web_ids.js
+++ b/lib/web_ids.js
@@ -155,9 +155,9 @@ function checkRequest(request) {
       }
 
       const message = method + ' from ip ' + request.srcip +
-                      ' on ' + uri + ' with status ' +
-                      status + ' and matched against following signature: ' +
-                      signature;
+                      ' on "' + uri + '" with status ' +
+                      status + ' matched against the following signature: ' +
+                      JSON.stringify(signature);
 
       appendToLog(LOG_FILE, type, message);
 


### PR DESCRIPTION
This fixes #18
Signature is now output as json formatted object